### PR TITLE
fix: `sequencer.stopped` flag in `kona-node`

### DIFF
--- a/src/cl/kona-node/launcher.star
+++ b/src/cl/kona-node/launcher.star
@@ -255,7 +255,7 @@ def get_service_config(
                     conductor_params.ports[_net.RPC_PORT_NAME],
                 )
             ),
-            "--sequencer.stopped=true",
+            "--sequencer.stopped",
         ]
 
     if len(cl_contexts) > 0:


### PR DESCRIPTION
## Overview

Fixes the `sequencer.stopped` flag in the `kona-node` launcher.