### PR TITLE
chore: Remove `--l2-provider-rpc` endpoint

### DIFF
--- a/src/cl/kona-node/launcher.star
+++ b/src/cl/kona-node/launcher.star
@@ -184,8 +184,6 @@ def get_service_config(
         EXECUTION_ENGINE_ENDPOINT,
         "--l2-engine-jwt-secret",
         _ethereum_package_constants.JWT_MOUNT_PATH_ON_CONTAINER,
-        "--l2-provider-rpc",
-        EXECUTION_ENGINE_ENDPOINT,
         "--l2-config-file",
         "{0}/rollup-{1}.json".format(
             _ethereum_package_constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS,

--- a/test/cl/launcher_test.star
+++ b/test/cl/launcher_test.star
@@ -192,8 +192,6 @@ def test_l2_participant_cl_launcher_kona_node(plan):
             "http://0.0.0.0:8888",
             "--l2-engine-jwt-secret",
             "/jwt/jwtsecret",
-            "--l2-provider-rpc",
-            "http://0.0.0.0:8888",
             "--l2-config-file",
             "/network-configs/rollup-2151908.json",
             "--p2p.advertise.ip",


### PR DESCRIPTION
## Overview

Removes the `--l2-provider-rpc` flag from the `kona-node` launcher